### PR TITLE
Fix JSON Parse error

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -9,7 +9,7 @@ declare const aws_cloud_logic_custom
 @Injectable()
 export class AwsConfig {
   public load () {
-    let aws_cloud_logic_custom_obj = JSON.parse(aws_cloud_logic_custom)
+    let aws_cloud_logic_custom_obj = aws_cloud_logic_custom
     return {
       'region': aws_cognito_region, // region you are deploying (all lower caps, e.g: us-east-1)
       'userPoolId': aws_user_pools_id, // your user pool ID


### PR DESCRIPTION
Currently, an ``ionic serve`` would cause this error:
``SyntaxError: Unexpected token o in JSON at position 1``
This small fix gets rid of it.