### PR TITLE
from aws-config.js, JSON parse is unnecessary.

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -9,14 +9,13 @@ declare const aws_cloud_logic_custom
 @Injectable()
 export class AwsConfig {
   public load () {
-    let aws_cloud_logic_custom_obj = JSON.parse(aws_cloud_logic_custom)
     return {
       'region': aws_cognito_region, // region you are deploying (all lower caps, e.g: us-east-1)
       'userPoolId': aws_user_pools_id, // your user pool ID
       'appId': aws_user_pools_web_client_id, // your user pool app ID
       'idpURL': `cognito-idp.${aws_cognito_region}.amazonaws.com`, // cognito idp url
       'identityPool': aws_cognito_identity_pool_id, // your federated identity pool ID
-      'APIs': aws_cloud_logic_custom_obj.reduce((m, v) => { m[v.name] = v.endpoint; return m }, {})
+      'APIs': aws_cloud_logic_custom.reduce((m, v) => { m[v.name] = v.endpoint; return m }, {})
     }
   }
 }


### PR DESCRIPTION
Currently, 'AWS Mobile Hub Management Console' exports aws-config.js.

`var aws_cloud_logic_custom = [{"id":"...","name":"TasksAPI","description":"","endpoint":"...","region":"...","paths":["/tasks","/tasks/123"]},{"id":"...","name":"ProjectsAPI","description":"","endpoint":"...","region":"...","paths":["/projects","/projects/123"]}];`

'aws_cloud_logic_custom' as array, JSON parse is unnecessary.

