### PR TITLE
FIX: aws_sdk_global__.util.crypto.lib.randomBytes is not a function

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
     "@ionic-native/splash-screen": "3.12.1",
     "@ionic-native/status-bar": "3.12.1",
     "@ionic/storage": "2.0.1",
-    "amazon-cognito-identity-js": "1.19.0",
+    "amazon-cognito-identity-js": "^2.0.5",
     "aws4": "^1.6.0",
     "crypto-js": "^3.1.9-1",
     "immutable": "^3.8.1",


### PR DESCRIPTION
On signin, an error

__WEBPACK_IMPORTED_MODULE_0_aws_sdk_global__.util.crypto.lib.randomBytes is not a function
    at AuthenticationHelper.generateRandomSmallA (main.js:97047)
    at new AuthenticationHelper (main.js:97013)
    at CognitoUser.authenticateUser (main.js:100828)
    at main.js:42653

